### PR TITLE
Enable to reset card swipe

### DIFF
--- a/lib/src/main/java/com/alexstyl/swipeablecard/SwipeableCardState.kt
+++ b/lib/src/main/java/com/alexstyl/swipeablecard/SwipeableCardState.kt
@@ -43,8 +43,8 @@ class SwipeableCardState(
     var swipedDirection: Direction? by mutableStateOf(null)
         private set
 
-    internal suspend fun reset() {
-        offset.animateTo(offset(0f, 0f), tween(400))
+    suspend fun reset(animationSpec: AnimationSpec<Offset> = tween(400)) {
+        offset.animateTo(offset(0f, 0f), animationSpec)
     }
 
     suspend fun swipe(direction: Direction, animationSpec: AnimationSpec<Offset> = tween(400)) {


### PR DESCRIPTION
With a public reset function, we could reset the card swipe, for example on an api error.